### PR TITLE
Karaf with resolved features image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
-- karaf container `HEALTHCHECK`
+- Karaf base image with resolved bundles from features file
+- Karaf container `HEALTHCHECK`
 
 # 0.2.0
 - latest AET from `master` (with Chrome support and new OSGi configurations)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Unreleased
 - Karaf base image with resolved bundles from features file
-- Karaf container `HEALTHCHECK`
+- Karaf container `HEALTHCHECK` (in swarm config)
+    - Original `HEALTHCHECK` from the Karaf's Dockerfile was moved to swarm config because of some odd behaviour (container never was `healthy` when multi-stage build was applied)
+    ```
+    ARG HEALTHCHECK_PHRASE="204 bundles in total - all 204 bundles active"
+    HEALTHCHECK --interval=1m --timeout=10s --start-period=120s \
+       CMD curl -v --silent http://karaf:karaf@localhost:8181/system/console/bundles 2>&1 | grep -Fq ${HEALTHCHECK_PHRASE} || exit 1
+    ```
+- version of compose-file upgraded from `3` to `3.6` (for the healthcheck `start_period` option), notice it requires Docker Engine `18.02.0+`
 
 # 0.2.0
 - latest AET from `master` (with Chrome support and new OSGi configurations)

--- a/aet-swarm.yml
+++ b/aet-swarm.yml
@@ -77,14 +77,14 @@ services:
       - private
 
   activemq:
-    image: skejven/aet_activemq:0.3.0
+    image: skejven/aet_activemq:0.2.0
     ports:
       - "8161:8161"
     networks:
       - private
 
   browsermob:
-   image: skejven/aet_browsermob:0.3.0
+   image: skejven/aet_browsermob:0.2.0
    ports:
     - "8080:8080"
     - "8281-8681:8281-8681"
@@ -92,7 +92,7 @@ services:
      - private
 
   karaf:
-    image: skejven/aet_karaf:0.3.0
+    image: skejven/aet_karaf:0.2.0
     depends_on:
       - hub
       - activemq

--- a/aet-swarm.yml
+++ b/aet-swarm.yml
@@ -77,14 +77,14 @@ services:
       - private
 
   activemq:
-    image: skejven/aet_activemq:0.2.0
+    image: skejven/aet_activemq:0.3.0
     ports:
       - "8161:8161"
     networks:
       - private
 
   browsermob:
-   image: skejven/aet_browsermob:0.2.0
+   image: skejven/aet_browsermob:0.3.0
    ports:
     - "8080:8080"
     - "8281-8681:8281-8681"
@@ -92,7 +92,7 @@ services:
      - private
 
   karaf:
-    image: skejven/aet_karaf:0.2.0
+    image: skejven/aet_karaf:0.3.0
     depends_on:
       - hub
       - activemq

--- a/aet-swarm.yml
+++ b/aet-swarm.yml
@@ -18,7 +18,7 @@
 #
 # To execute this docker-swarm yml file use `docker stack deploy -c aet-swarm.yml aet`
 
-version: '3'
+version: '3.6'
 
 networks:
   private:
@@ -93,6 +93,12 @@ services:
 
   karaf:
     image: skejven/aet_karaf:0.2.0
+    healthcheck:
+      test: curl -v --silent http://karaf:karaf@localhost:8181/system/console/bundles 2>&1 | grep -Fq "204 bundles in total - all 204 bundles active" || exit 1
+      interval: 1m
+      timeout: 10s
+      retries: 3
+      start_period: 120s
     depends_on:
       - hub
       - activemq

--- a/karaf/Dockerfile
+++ b/karaf/Dockerfile
@@ -20,16 +20,17 @@ FROM openjdk:8-alpine as build
 MAINTAINER Maciej Laskowski <maciej.laskowski@cognifide.com>
 
 # Set the env params
-ENV KARAF_USER karaf
-ENV KARAF_UID 8181
-ENV JAVA_MAX_MEM 512m
+#ENV KARAF_USER karaf
+#ENV KARAF_UID 8181
+ENV JAVA_MAX_MEM 1024m
+ENV JAVA_MIN_MEM 256m
 ENV KARAF_EXEC exec
 ENV KARAF_VERSION=4.2.0
 
 COPY download.sh /tmp/download.sh
 
-RUN addgroup -S -g ${KARAF_UID} ${KARAF_USER}; \
-    adduser -S -u ${KARAF_UID} -g ${KARAF_USER} ${KARAF_USER}
+#RUN addgroup -S -g ${KARAF_UID} ${KARAF_USER}; \
+#    adduser -S -u ${KARAF_UID} -g ${KARAF_USER} ${KARAF_USER}
 
 RUN apk add --update bash tar jq curl && rm -rf /var/cache/apk/* \
     && chmod a+x /tmp/download.sh && sync && /tmp/download.sh && rm /tmp/download.sh \
@@ -37,7 +38,7 @@ RUN apk add --update bash tar jq curl && rm -rf /var/cache/apk/* \
     && tar --strip-components=1 -C /opt/karaf -xzf /tmp/apache-karaf.tar.gz \
     && rm /tmp/apache-karaf.tar.gz \
     && mkdir -p /opt/karaf/data /opt/karaf/data/log \
-    && chown -R ${KARAF_USER}.${KARAF_USER} /opt/karaf \
+#    && chown -R ${KARAF_USER}.${KARAF_USER} /opt/karaf \
     && echo org.ops4j.pax.url.mvn.defaultRepositories = file:///opt/maven/repository@id=local.app@snapshots  >> /opt/karaf/etc/org.ops4j.pax.url.mvn.cfg
 
 # Copy and unzip AET features
@@ -55,15 +56,22 @@ FROM openjdk:8-alpine as final
 # Set the env params
 ENV KARAF_USER karaf
 ENV KARAF_UID 8181
-ENV JAVA_MAX_MEM 512m
+ENV JAVA_MAX_MEM 1024m
+ENV JAVA_MIN_MEM 256m
 ENV KARAF_EXEC exec
 ENV KARAF_VERSION=4.2.0
 
 ARG HEALTHCHECK_PHRASE="204 bundles in total - all 204 bundles active"
 
+RUN addgroup -S -g ${KARAF_UID} ${KARAF_USER}; \
+    adduser -S -u ${KARAF_UID} -g ${KARAF_USER} ${KARAF_USER}
+
 RUN apk add --update bash curl tar && rm -rf /var/cache/apk/*
 
 COPY --from=build /opt/karaf /opt/karaf
+
+RUN chown -R ${KARAF_USER}.${KARAF_USER} /opt/karaf \
+    && echo org.ops4j.pax.url.mvn.defaultRepositories = file:///opt/maven/repository@id=local.app@snapshots  >> /opt/karaf/etc/org.ops4j.pax.url.mvn.cfg
 
 # Copy and unzip AET bundles
 COPY bundles.zip /tmp/

--- a/karaf/Dockerfile
+++ b/karaf/Dockerfile
@@ -20,6 +20,7 @@ FROM openjdk:8-alpine as build
 MAINTAINER Maciej Laskowski <maciej.laskowski@cognifide.com>
 
 # Set the env params
+ENV KARAF_USER karaf
 ENV KARAF_UID 8181
 ENV JAVA_MAX_MEM 512m
 ENV KARAF_EXEC exec

--- a/karaf/Dockerfile
+++ b/karaf/Dockerfile
@@ -20,8 +20,6 @@ FROM openjdk:8-alpine as build
 MAINTAINER Maciej Laskowski <maciej.laskowski@cognifide.com>
 
 # Set the env params
-#ENV KARAF_USER karaf
-#ENV KARAF_UID 8181
 ENV JAVA_MAX_MEM 1024m
 ENV JAVA_MIN_MEM 256m
 ENV KARAF_EXEC exec
@@ -29,16 +27,12 @@ ENV KARAF_VERSION=4.2.0
 
 COPY download.sh /tmp/download.sh
 
-#RUN addgroup -S -g ${KARAF_UID} ${KARAF_USER}; \
-#    adduser -S -u ${KARAF_UID} -g ${KARAF_USER} ${KARAF_USER}
-
 RUN apk add --update bash tar jq curl && rm -rf /var/cache/apk/* \
     && chmod a+x /tmp/download.sh && sync && /tmp/download.sh && rm /tmp/download.sh \
     && mkdir -p /opt/karaf \
     && tar --strip-components=1 -C /opt/karaf -xzf /tmp/apache-karaf.tar.gz \
     && rm /tmp/apache-karaf.tar.gz \
     && mkdir -p /opt/karaf/data /opt/karaf/data/log \
-#    && chown -R ${KARAF_USER}.${KARAF_USER} /opt/karaf \
     && echo org.ops4j.pax.url.mvn.defaultRepositories = file:///opt/maven/repository@id=local.app@snapshots  >> /opt/karaf/etc/org.ops4j.pax.url.mvn.cfg
 
 # Copy and unzip AET features
@@ -46,8 +40,8 @@ COPY features.zip /tmp/
 RUN unzip -o /tmp/features.zip -d /opt/karaf/deploy && rm /tmp/features.zip
 
 # Run karaf and wait until it downloads all features
-COPY check-karaf.sh /tmp/check-karaf.sh
-RUN chmod a+x /tmp/check-karaf.sh && sync && /tmp/check-karaf.sh
+COPY provision-karaf.sh /tmp/provision-karaf.sh
+RUN chmod a+x /tmp/provision-karaf.sh && sync && /tmp/provision-karaf.sh
 
 #################################################################################
 
@@ -60,8 +54,6 @@ ENV JAVA_MAX_MEM 1024m
 ENV JAVA_MIN_MEM 256m
 ENV KARAF_EXEC exec
 ENV KARAF_VERSION=4.2.0
-
-ARG HEALTHCHECK_PHRASE="204 bundles in total - all 204 bundles active"
 
 RUN addgroup -S -g ${KARAF_UID} ${KARAF_USER}; \
     adduser -S -u ${KARAF_UID} -g ${KARAF_USER} ${KARAF_USER}
@@ -82,8 +74,5 @@ COPY configs/ /opt/karaf/etc
 EXPOSE 1099 8101 8181 44444
 
 USER ${KARAF_USER}
-
-HEALTHCHECK --interval=1m --timeout=10s --start-period=120s \
-  CMD curl -v --silent http://karaf:karaf@localhost:8181/system/console/bundles 2>&1 | grep -Fq ${HEALTHCHECK_PHRASE} || exit 1
 
 CMD ["/opt/karaf/bin/karaf", "run"]

--- a/karaf/Dockerfile
+++ b/karaf/Dockerfile
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-FROM openjdk:8-alpine
+FROM openjdk:8-alpine as build
 MAINTAINER Maciej Laskowski <maciej.laskowski@cognifide.com>
 
 # Set the env params
@@ -25,8 +25,6 @@ ENV KARAF_UID 8181
 ENV JAVA_MAX_MEM 512m
 ENV KARAF_EXEC exec
 ENV KARAF_VERSION=4.2.0
-
-ARG HEALTHCHECK_PHRASE="204 bundles in total - all 204 bundles active"
 
 COPY download.sh /tmp/download.sh
 
@@ -43,9 +41,33 @@ RUN apk add --update bash tar jq curl && rm -rf /var/cache/apk/* \
     && echo org.ops4j.pax.url.mvn.defaultRepositories = file:///opt/maven/repository@id=local.app@snapshots  >> /opt/karaf/etc/org.ops4j.pax.url.mvn.cfg
 
 # Copy and unzip AET artifacts
-COPY bundles.zip features.zip /tmp/
-RUN unzip -o /tmp/bundles.zip -d /opt/karaf/deploy && rm /tmp/bundles.zip \
-  && unzip -o /tmp/features.zip -d /opt/karaf/deploy && rm /tmp/features.zip
+COPY features.zip /tmp/
+RUN unzip -o /tmp/features.zip -d /opt/karaf/deploy && rm /tmp/features.zip
+
+# Run karaf and wait until it downloads all features
+COPY check-karaf.sh /tmp/check-karaf.sh
+RUN chmod a+x /tmp/check-karaf.sh && sync && /tmp/check-karaf.sh
+
+#################################################################################
+
+FROM openjdk:8-alpine as final
+
+# Set the env params
+ENV KARAF_USER karaf
+ENV KARAF_UID 8181
+ENV JAVA_MAX_MEM 512m
+ENV KARAF_EXEC exec
+ENV KARAF_VERSION=4.2.0
+
+ARG HEALTHCHECK_PHRASE="204 bundles in total - all 204 bundles active"
+
+RUN apk add --update bash curl tar && rm -rf /var/cache/apk/*
+
+COPY --from=build /opt/karaf /opt/karaf
+
+# Copy and unzip AET artifacts
+COPY bundles.zip /tmp/
+RUN unzip -o /tmp/bundles.zip -d /opt/karaf/deploy && rm /tmp/bundles.zip
 
 COPY configs/ /opt/karaf/etc
 

--- a/karaf/Dockerfile
+++ b/karaf/Dockerfile
@@ -20,7 +20,6 @@ FROM openjdk:8-alpine as build
 MAINTAINER Maciej Laskowski <maciej.laskowski@cognifide.com>
 
 # Set the env params
-ENV KARAF_USER karaf
 ENV KARAF_UID 8181
 ENV JAVA_MAX_MEM 512m
 ENV KARAF_EXEC exec
@@ -40,7 +39,7 @@ RUN apk add --update bash tar jq curl && rm -rf /var/cache/apk/* \
     && chown -R ${KARAF_USER}.${KARAF_USER} /opt/karaf \
     && echo org.ops4j.pax.url.mvn.defaultRepositories = file:///opt/maven/repository@id=local.app@snapshots  >> /opt/karaf/etc/org.ops4j.pax.url.mvn.cfg
 
-# Copy and unzip AET artifacts
+# Copy and unzip AET features
 COPY features.zip /tmp/
 RUN unzip -o /tmp/features.zip -d /opt/karaf/deploy && rm /tmp/features.zip
 
@@ -65,7 +64,7 @@ RUN apk add --update bash curl tar && rm -rf /var/cache/apk/*
 
 COPY --from=build /opt/karaf /opt/karaf
 
-# Copy and unzip AET artifacts
+# Copy and unzip AET bundles
 COPY bundles.zip /tmp/
 RUN unzip -o /tmp/bundles.zip -d /opt/karaf/deploy && rm /tmp/bundles.zip
 

--- a/karaf/check-karaf.sh
+++ b/karaf/check-karaf.sh
@@ -1,0 +1,53 @@
+#
+# AET
+#
+# Copyright (C) 2013 Cognifide Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#!/bin/sh
+
+KARAF_URL=http://karaf:karaf@localhost:8181/system/console/bundles
+
+get_status_code() {
+  curl -s -o /dev/null -w "%{http_code}" ${KARAF_URL}
+}
+
+get_bundles_status() {
+  curl -s ${KARAF_URL} | grep -o '{"status".*}]}' | jq '.status'
+}
+
+echo "Start waiting for Karaf to load features - up to 200 seconds, waiting for 188 active bundles"
+
+/opt/karaf/bin/karaf run &
+
+for i in $(seq 0 60);
+do
+  sec=$((5 * $i))
+  if curl -v -s ${KARAF_URL} 2>&1 | grep -Fq "188 bundles active";
+  then
+    echo "Karaf loading finished after $sec seconds";
+    get_bundles_status
+    exit 0;
+  else
+    status_code=$(get_status_code)
+    echo "Karaf loading from $sec sec... response: $status_code";
+    if [ "$status_code" -eq 200 ]
+    then
+      get_bundles_status
+    fi;
+    sleep 5;
+  fi;
+done
+
+exit 1;

--- a/karaf/check-karaf.sh
+++ b/karaf/check-karaf.sh
@@ -38,6 +38,7 @@ do
   then
     echo "Karaf loading finished after $sec seconds";
     get_bundles_status
+    /opt/karaf/bin/karaf stop
     exit 0;
   else
     status_code=$(get_status_code)

--- a/karaf/provision-karaf.sh
+++ b/karaf/provision-karaf.sh
@@ -39,6 +39,7 @@ do
     echo "Karaf loading finished after $sec seconds";
     get_bundles_status
     /opt/karaf/bin/karaf stop
+    echo "Status: $(/opt/karaf/bin/karaf status)"
     exit 0;
   else
     status_code=$(get_status_code)


### PR DESCRIPTION
Original `HEALTHCHECK` from the Karaf's Dockerfile was moved to swarm config because of some odd behaviour (container never was `healthy` when multi-stage build was applied)

```
  ARG HEALTHCHECK_PHRASE="204 bundles in total - all 204 bundles active"
  HEALTHCHECK --interval=1m --timeout=10s --start-period=120s \
     CMD curl -v --silent http://karaf:karaf@localhost:8181/system/console/bundles 2>&1 | grep -Fq ${HEALTHCHECK_PHRASE} || exit 1
```