### PR TITLE
Incorrect format of ChromeWebDriverFactory config

### DIFF
--- a/karaf/configs/com.cognifide.aet.worker.drivers.chrome.ChromeWebDriverFactory.cfg
+++ b/karaf/configs/com.cognifide.aet.worker.drivers.chrome.ChromeWebDriverFactory.cfg
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-name=chrome
-seleniumGridUrl=http://hub:4444/wd/hub
+name = "chrome"
+seleniumGridUrl = "http://hub:4444/wd/hub"
 chromeOptions = [ \
   "--disable-plugins", \
   "--headless", \
@@ -30,4 +30,4 @@ chromeOptions = [ \
   "--disable-dev-shm-usage", \
   "--disable-browser-side-navigation", \
   "--dns-prefetch-disable", \
-  ]
+]

--- a/karaf/configs/com.cognifide.aet.worker.drivers.chrome.ChromeWebDriverFactory.cfg
+++ b/karaf/configs/com.cognifide.aet.worker.drivers.chrome.ChromeWebDriverFactory.cfg
@@ -3,14 +3,14 @@
 #
 # Copyright (C) 2013 Cognifide Limited
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License, Version 2.0 (the License);
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
 #      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the License is distributed on an AS IS BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.


### PR DESCRIPTION
ChromeWebDriverFactory config format updated to ensure that array property will be parsed as an array, not as a string.

The change itself may look a bit strange, but it turned out this is the only way to make an array out of `chromeOptions`. I tested multiple formats and that was the only one that works.

Fixes #3