### PR TITLE
Fix example swarm

### DIFF
--- a/example-aet-swarm/aet-swarm.yml
+++ b/example-aet-swarm/aet-swarm.yml
@@ -144,6 +144,7 @@ services:
     ports:
       - "8181:8181"
 #      - "5005:5005" # uncomment to be able to connect Karaf in debug mode
+    environment:
 #      - KARAF_DEBUG=true # uncomment to start Karaf in debug mode
     networks:
       - private


### PR DESCRIPTION
Debug flag was present in the wrong section of YML, causing error when trying to use the debug mode