### PR TITLE
Support for AET app devs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ kubernetes
 atlassian-ide-plugin.xml
 .DS_Store
 **/generated/
+
+# Dev environment
+example-aet-swarm/bundles/*
+example-aet-swarm/features/*
+example-aet-swarm/report/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: required
+
+services:
+  - docker
+
+before_script:
+  - chmod u+x build.sh
+
+script:
+  - ./build.sh travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+# Just to check if images are building correctly
 sudo: required
 
 services:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Not released yet
 Not releaset yet changes
-- Support for AET application developers
+- [Support for AET application developers](https://github.com/Skejven/aet-docker/pull/10)
 
 ## Upgrade notes
 All Karaf AET artifacts (`bundles`, `features` and `configs`) are now stored in the Karaf Container in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Not released yet
 Not releaset yet changes
+- Support for AET application developers
+
+## Upgrade notes
+All Karaf AET artifacts (`bundles`, `features` and `configs`) are now stored in the Karaf Container in
+the `/aet` location:
+```
+├── aet
+│   ├── bundles
+│   ├── configs
+│   └── features
+```
+The main change concerns `configs` which were previously stored directly under root `/configs` inside
+the Karaf container. Remember to adjust your instance deployment config to that change.
 
 # 0.9.0
 - [Fixed](https://github.com/Skejven/aet-docker/commit/881f0ac6c7e115ca3d1c830f76384a586a1cb660) ActiveMQ not working jmx interface

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ You should see following images:
 
 ## Developer environment
 Since version `v0.10.0` [example swarm instance](#running-aet-instance-with-docker-swarm)
-supports for AET developers.
+supports AET developers.
 In order to be able to easily deploy AET artifacts on your docker instance follow these steps:
 
 > Notice, this example shows how to configure full-stack AET dev environemnt.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Contents of the `AET_ROOT` directory should look like:
    you should change `aet-swarm.yml` `volumes` section for the `karaf` service to:
     ```yaml
         volumes:
-          - /osgi-configs/configs:/configs # when using docker-machine, use mounted folder
+          - /osgi-configs/configs:/aet/configs # when using docker-machine, use mounted folder
     ```
 3. From the `AET_ROOT` run `docker stack deploy -c aet-swarm.yml aet`.
 4. Wait about 1-2 minutes until Karaf start finishes.
@@ -314,3 +314,50 @@ You should see following images:
     skejven/aet_browsermob:{tag}
     skejven/aet_activemq:{tag}
 ```
+
+## Developer environment
+Since version `v0.10.0` [example swarm instance](#running-aet-instance-with-docker-swarm)
+supports for AET developers.
+In order to be able to easily deploy AET artifacts on your docker instance follow these steps:
+
+> Notice, this example shows how to configure full-stack AET dev environemnt.
+  If you want to e.g. work only over AET bundles, you don't have to configure feature files
+  or report application. Just configure `bundles` volume and skip adjustments for other parts of AET stack.
+
+
+1. Download `example-aet-swarm.zip` 
+from the [release](https://github.com/Skejven/aet-docker/releases) and unzip the files to the 
+folder from where docker stack will be deployed (from now on we will call it `AET_ROOT`).
+
+2. Edit `aet-swarm.yml` and uncomment `karaf` and `report` services volumes:
+  ```yaml
+    karaf:
+      ...
+      volumes:
+        - ./configs:/aet/configs
+        - ./bundles:/aet/bundles
+        - ./features:/aet/features
+        
+     ...
+        
+     report:
+       ...
+       volumes:
+         - ./report:/var/www/html
+  ```
+3. Adjust structure of the `AET_ROOT` to:
+  ```
+  ├── aet-swarm.yml
+  ├── bundles
+  ├── configs
+  ├── features
+  └── report
+  ```
+4. Build [AET application](https://github.com/Cognifide/aet) and move all artifacts tho the right places:
+- AET bundles to the `bundles` directory
+- OSGi feature files into the `features`
+- `configs` directory already contains setup configs
+- report files into the `report` directory
+
+5. Now like in [instance setup](#instance-setup) steps,
+ run `docker stack deploy -c aet-swarm.yml aet` to enoy your AET dev stack. 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ You may find released versions of AET Docker images at [Docker Hub](https://clou
   * [Is there other way to run AET than with Docker Swarm cluster](#is-there-other-way-to-run-aet-than-with-docker-swarm-cluster)
 - [Building](#building)
   * [Prerequisites](#prerequisites-1)
+- [Developer environment](#developer-environment)
 
 
 ## Docker Images

--- a/example-aet-swarm/aet-swarm.yml
+++ b/example-aet-swarm/aet-swarm.yml
@@ -77,14 +77,14 @@ services:
       - private
 
   activemq:
-    image: skejven/aet_activemq:0.9.0
+    image: skejven/aet_activemq:0.10.0
     ports:
       - "8161:8161"
     networks:
       - private
 
   browsermob:
-   image: skejven/aet_browsermob:0.9.0
+   image: skejven/aet_browsermob:0.10.0
    ports:
     - "8080:8080"
     - "8281-8681:8281-8681"
@@ -92,7 +92,7 @@ services:
      - private
 
   karaf:
-    image: skejven/aet_karaf:0.9.0
+    image: skejven/aet_karaf:0.10.0
     healthcheck:
       test: curl -v --silent http://karaf:karaf@localhost:8181/system/console/bundles 2>&1 | grep -Fq "203 bundles in total - all 203 bundles active" || exit 1
       interval: 1m
@@ -103,8 +103,9 @@ services:
       - hub
       - activemq
     volumes:
-      - ./configs:/configs
-#      - /osgi-configs/configs:/configs # when using docker-machine, use mounted folder
+      - ./configs:/aet/configs
+#      - ./bundles:/aet/bundles
+#      - ./features:/aet/features
     ports:
       - "8181:8181"
 #      - "5005:5005" # uncomment to be able to connect Karaf in debug mode
@@ -114,8 +115,10 @@ services:
       - private
 
   report:
-    image: skejven/aet_report:0.9.0
+    image: skejven/aet_report:0.10.0
     ports:
       - "80:80"
+#    volumes:
+#      - ./report:/var/www/html
     networks:
       - private

--- a/karaf/Dockerfile
+++ b/karaf/Dockerfile
@@ -75,12 +75,23 @@ RUN apk add --update bash curl tar && rm -rf /var/cache/apk/*
 
 COPY --from=build /opt/karaf /opt/karaf
 
+# Copy Karaf config to watch for AET artifacts
+COPY etc/org.apache.felix.fileinstall-bundles.cfg /opt/karaf/etc/org.apache.felix.fileinstall-bundles.cfg
+COPY etc/org.apache.felix.fileinstall-configs.cfg /opt/karaf/etc/org.apache.felix.fileinstall-configs.cfg
+COPY etc/org.apache.felix.fileinstall-features.cfg /opt/karaf/etc/org.apache.felix.fileinstall-features.cfg
+
+# Create AET artifacts deployment structure
+RUN mkdir -p /aet/bundles /aet/configs /aet/features \
+  && chown -R ${KARAF_USER}.${KARAF_USER} /aet
+
 # Download and unzip AET bundles
 RUN curl -fSL -o /tmp/${AET_ARTIFACT} ${AET_ARTIFACT_DOWNLOAD_URL} \
-  && unzip -o /tmp/${AET_ARTIFACT} -d /opt/karaf/deploy && rm /tmp/${AET_ARTIFACT}
+  && unzip -o /tmp/${AET_ARTIFACT} -d /aet/bundles && rm /tmp/${AET_ARTIFACT} \
+  && chown -R ${KARAF_USER}.${KARAF_USER} /aet/bundles
 
-# Copy Karaf config to watch for OSGi configs
-COPY etc/org.apache.felix.fileinstall-docker.cfg /opt/karaf/etc/org.apache.felix.fileinstall-docker.cfg
+# Move AET features files into the right place
+RUN mv /opt/karaf/deploy/aet-*.xml /aet/features \
+  && chown -R ${KARAF_USER}.${KARAF_USER} /aet/features
 
 RUN chown -R ${KARAF_USER}.${KARAF_USER} /opt/karaf \
     && echo org.ops4j.pax.url.mvn.defaultRepositories = file:///opt/maven/repository@id=local.app@snapshots  >> /opt/karaf/etc/org.ops4j.pax.url.mvn.cfg

--- a/karaf/etc/org.apache.felix.fileinstall-bundles.cfg
+++ b/karaf/etc/org.apache.felix.fileinstall-bundles.cfg
@@ -1,0 +1,2 @@
+# Monitor OSGi AET bundles in the root /aet directory
+felix.fileinstall.dir=/aet/bundles

--- a/karaf/etc/org.apache.felix.fileinstall-configs.cfg
+++ b/karaf/etc/org.apache.felix.fileinstall-configs.cfg
@@ -1,0 +1,2 @@
+# Monitor OSGi AET configs in the root /aet directory
+felix.fileinstall.dir=/aet/configs

--- a/karaf/etc/org.apache.felix.fileinstall-docker.cfg
+++ b/karaf/etc/org.apache.felix.fileinstall-docker.cfg
@@ -1,2 +1,0 @@
-# Monitor OSGi AET configs in the root /configs directory
-felix.fileinstall.dir=/configs

--- a/karaf/etc/org.apache.felix.fileinstall-features.cfg
+++ b/karaf/etc/org.apache.felix.fileinstall-features.cfg
@@ -1,0 +1,2 @@
+# Monitor OSGi AET features in the root /aet directory
+felix.fileinstall.dir=/aet/features


### PR DESCRIPTION
## Developer environment
Since version `v0.10.0`, example swarm instance supports AET developers.
In order to be able to easily deploy AET artifacts on your docker instance follow these steps:

> Notice, this example shows how to configure full-stack AET dev environemnt.
  If you want to e.g. work only over AET bundles, you don't have to configure feature files
  or report application. Just configure `bundles` volume and skip adjustments for other parts of AET stack.


1. Download `example-aet-swarm.zip` 
from the [release](https://github.com/Skejven/aet-docker/releases) and unzip the files to the 
folder from where docker stack will be deployed (from now on we will call it `AET_ROOT`).

2. Edit `aet-swarm.yml` and uncomment `karaf` and `report` services volumes:
  ```yaml
    karaf:
      ...
      volumes:
        - ./configs:/aet/configs
        - ./bundles:/aet/bundles
        - ./features:/aet/features
        
     ...
        
     report:
       ...
       volumes:
         - ./report:/var/www/html
  ```
3. Adjust structure of the `AET_ROOT` to:
  ```
  ├── aet-swarm.yml
  ├── bundles
  ├── configs
  ├── features
  └── report
  ```
4. Build [AET application](https://github.com/Cognifide/aet) and move all artifacts tho the right places:
- AET bundles to the `bundles` directory
- OSGi feature files into the `features`
- `configs` directory already contains setup configs
- report files into the `report` directory

5. Now like in [instance setup](#instance-setup) steps,
 run `docker stack deploy -c aet-swarm.yml aet` to enoy your AET dev stack. 