### PR TITLE
Use json form of osgi console bundles in healthchecks

### DIFF
--- a/example-aet-swarm/aet-swarm.yml
+++ b/example-aet-swarm/aet-swarm.yml
@@ -94,7 +94,7 @@ services:
   karaf:
     image: skejven/aet_karaf:0.12.0
     healthcheck:
-      test: curl -v --silent http://karaf:karaf@localhost:8181/system/console/bundles 2>&1 | grep -Fq "204 bundles in total - all 204 bundles active" || exit 1
+      test: curl --silent http://karaf:karaf@localhost:8181/system/console/bundles.json 2>&1 | jq '.status' | grep -Fq "204 bundles in total - all 204 bundles active" || exit 1
       interval: 1m
       timeout: 10s
       retries: 3

--- a/karaf/Dockerfile
+++ b/karaf/Dockerfile
@@ -71,7 +71,7 @@ ARG AET_ARTIFACT_DOWNLOAD_URL="https://github.com/Cognifide/aet/releases/downloa
 RUN addgroup -S -g ${KARAF_UID} ${KARAF_USER}; \
     adduser -S -u ${KARAF_UID} -g ${KARAF_USER} ${KARAF_USER}
 
-RUN apk add --update bash curl tar && rm -rf /var/cache/apk/*
+RUN apk add --update bash jq curl tar && rm -rf /var/cache/apk/*
 
 COPY --from=build /opt/karaf /opt/karaf
 

--- a/karaf/provision-karaf.sh
+++ b/karaf/provision-karaf.sh
@@ -17,14 +17,14 @@
 #
 #!/bin/sh
 
-KARAF_URL=http://karaf:karaf@localhost:8181/system/console/bundles
+KARAF_URL=http://karaf:karaf@localhost:8181/system/console/bundles.json
 
 get_status_code() {
   curl -s -o /dev/null -w "%{http_code}" ${KARAF_URL}
 }
 
 get_bundles_status() {
-  curl -s ${KARAF_URL} | grep -o '{"status".*}]}' | jq '.status'
+  curl -s ${KARAF_URL} | jq '.status'
 }
 
 echo "Start waiting for Karaf to load features - up to 200 seconds, waiting for 187 active bundles"
@@ -34,7 +34,7 @@ echo "Start waiting for Karaf to load features - up to 200 seconds, waiting for 
 for i in $(seq 0 60);
 do
   sec=$((5 * $i))
-  if curl -v -s ${KARAF_URL} 2>&1 | grep -Fq "187 bundles active";
+  if curl -s ${KARAF_URL} 2>&1 | jq '.status' | grep -Fq "187 bundles active";
   then
     echo "Karaf loading finished after $sec seconds";
     get_bundles_status


### PR DESCRIPTION
OSGi web console can return JSON results, e.g.: `localhost:8181/system/console/bundles.json`. Requesting it and parsing with `jq` gives more accurate results.