### PR TITLE
update maven repositories to use https over http

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Not released yet
 Nothing now :)
 
+# 0.12.1
+- [PR-17](https://github.com/Skejven/aet-docker/pull/17) Update maven repositories to use https over http. Fixes '501-https-required' error while downloading karaf dependecies. More info about the issue [here](https://support.sonatype.com/hc/en-us/articles/360041287334).
+
 # 0.12.0
 - [PR-11](https://github.com/Skejven/aet-docker/pull/11) Report docker image base changed from Ubuntu to `httpd` Alpine (`386 MB` to `150 MB`)
 - Removed suite generator from the report image (it lacks Open Source license)

--- a/karaf/Dockerfile
+++ b/karaf/Dockerfile
@@ -41,7 +41,8 @@ RUN curl -fSL -o /tmp/apache-karaf.tar.gz ${KARAF_DOWNLOAD_URL} \
     && tar --strip-components=1 -C /opt/karaf -xzf /tmp/apache-karaf.tar.gz \
     && rm /tmp/apache-karaf.tar.gz \
     && mkdir -p /opt/karaf/data /opt/karaf/data/log \
-    && echo org.ops4j.pax.url.mvn.defaultRepositories = file:///opt/maven/repository@id=local.app@snapshots  >> /opt/karaf/etc/org.ops4j.pax.url.mvn.cfg
+    && echo org.ops4j.pax.url.mvn.defaultRepositories = file:///opt/maven/repository@id=local.app@snapshots  >> /opt/karaf/etc/org.ops4j.pax.url.mvn.cfg \
+    && sed -i "s+http://+https://+g" /opt/karaf/etc/org.ops4j.pax.url.mvn.cfg
 
 # download and unzip AET features
 RUN curl -fSL -o /tmp/${AET_ARTIFACT} ${AET_ARTIFACT_DOWNLOAD_URL} \
@@ -97,7 +98,8 @@ RUN mv /opt/karaf/deploy/aet-*.xml /aet/features \
   && chown -R ${KARAF_USER}.${KARAF_USER} /aet/features
 
 RUN chown -R ${KARAF_USER}.${KARAF_USER} /opt/karaf \
-    && echo org.ops4j.pax.url.mvn.defaultRepositories = file:///opt/maven/repository@id=local.app@snapshots  >> /opt/karaf/etc/org.ops4j.pax.url.mvn.cfg
+    && echo org.ops4j.pax.url.mvn.defaultRepositories = file:///opt/maven/repository@id=local.app@snapshots  >> /opt/karaf/etc/org.ops4j.pax.url.mvn.cfg \
+    && sed -i "s+http://+https://+g" /opt/karaf/etc/org.ops4j.pax.url.mvn.cfg
 
 EXPOSE 1099 8101 8181 44444
 


### PR DESCRIPTION
"Effective January 15, 2020, The Central Repository no longer supports insecure communication over plain HTTP and requires that all requests to the repository are encrypted over HTTPS."

https://support.sonatype.com/hc/en-us/articles/360041287334