### PR TITLE
Extended development support and healthchecks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Not released yet
 Nothing now :)
+- [PR-20](https://github.com/Skejven/aet-docker/pull/20) - `core` and `custom` AET artifacts in the Karaf image and healthcheck basing on the [fabric8 healthchecks](https://fabric8.io/guide/karaf.html#add-custom-heath-checks).
 
 # 0.12.2
 - [PR-19](https://github.com/Skejven/aet-docker/pull/19) - Enable exposing AET WebAPI via Report server

--- a/example-aet-swarm/aet-swarm.yml
+++ b/example-aet-swarm/aet-swarm.yml
@@ -94,7 +94,7 @@ services:
   karaf:
     image: skejven/aet_karaf:0.12.2
     healthcheck:
-      test: curl --silent http://karaf:karaf@localhost:8181/system/console/bundles.json 2>&1 | jq '.status' | grep -Fq "204 bundles in total - all 204 bundles active" || exit 1
+      test: curl --fail http://karaf:karaf@localhost:8181/health-check
       interval: 1m
       timeout: 10s
       retries: 3
@@ -103,9 +103,9 @@ services:
       - hub
       - activemq
     volumes:
-      - ./configs:/aet/configs
-#      - ./bundles:/aet/bundles
-#      - ./features:/aet/features
+      - ./configs:/aet/custom/configs
+      - ./bundles:/aet/custom/bundles
+      - ./features:/aet/custom/features
     ports:
       - "8181:8181"
 #      - "5005:5005" # uncomment to be able to connect Karaf in debug mode

--- a/karaf/Dockerfile
+++ b/karaf/Dockerfile
@@ -77,25 +77,22 @@ RUN apk add --update bash jq curl tar && rm -rf /var/cache/apk/*
 COPY --from=build /opt/karaf /opt/karaf
 
 # Copy Karaf config to watch for AET artifacts
-COPY etc/org.apache.felix.fileinstall-bundles.cfg /opt/karaf/etc/org.apache.felix.fileinstall-bundles.cfg
-COPY etc/org.apache.felix.fileinstall-configs.cfg /opt/karaf/etc/org.apache.felix.fileinstall-configs.cfg
-COPY etc/org.apache.felix.fileinstall-features.cfg /opt/karaf/etc/org.apache.felix.fileinstall-features.cfg
+COPY etc/*.cfg /opt/karaf/etc/
 
 # Create AET artifacts deployment structure
-RUN mkdir -p /aet/bundles /aet/configs /aet/features \
+RUN mkdir -p /aet/core /aet/core/bundles /aet/core/features /aet/extra /aet/extra/bundles /aet/extra/configs /aet/extra/features \
   && chown -R ${KARAF_USER}.${KARAF_USER} /aet
 
 # Download and unzip AET bundles
 RUN curl -fSL -o /tmp/${AET_ARTIFACT} ${AET_ARTIFACT_DOWNLOAD_URL} \
-  && unzip -o /tmp/${AET_ARTIFACT} -d /aet/bundles && rm /tmp/${AET_ARTIFACT} \
-  && chown -R ${KARAF_USER}.${KARAF_USER} /aet/bundles
-
-# Add all extra bundles
-COPY extra /aet/bundles
+  && unzip -o /tmp/${AET_ARTIFACT} -d /aet/core/bundles && rm /tmp/${AET_ARTIFACT} \
+  && chown -R ${KARAF_USER}.${KARAF_USER} /aet/core/bundles \
+  && chown -R ${KARAF_USER}.${KARAF_USER} /aet/extra/bundles
 
 # Move AET features files into the right place
-RUN mv /opt/karaf/deploy/aet-*.xml /aet/features \
-  && chown -R ${KARAF_USER}.${KARAF_USER} /aet/features
+RUN mv /opt/karaf/deploy/aet-*.xml /aet/core/features \
+  && chown -R ${KARAF_USER}.${KARAF_USER} /aet/core/features \
+  && chown -R ${KARAF_USER}.${KARAF_USER} /aet/extra/features
 
 RUN chown -R ${KARAF_USER}.${KARAF_USER} /opt/karaf \
     && echo org.ops4j.pax.url.mvn.defaultRepositories = file:///opt/maven/repository@id=local.app@snapshots  >> /opt/karaf/etc/org.ops4j.pax.url.mvn.cfg \

--- a/karaf/etc/org.apache.felix.fileinstall-core-bundles.cfg
+++ b/karaf/etc/org.apache.felix.fileinstall-core-bundles.cfg
@@ -1,0 +1,2 @@
+# Monitor OSGi AET bundles in the root /aet directory
+felix.fileinstall.dir=/aet/core/bundles

--- a/karaf/etc/org.apache.felix.fileinstall-core-features.cfg
+++ b/karaf/etc/org.apache.felix.fileinstall-core-features.cfg
@@ -1,0 +1,2 @@
+# Monitor OSGi AET features in the root /aet directory
+felix.fileinstall.dir=/aet/core/features

--- a/karaf/etc/org.apache.felix.fileinstall-custom-bundles.cfg
+++ b/karaf/etc/org.apache.felix.fileinstall-custom-bundles.cfg
@@ -1,2 +1,2 @@
 # Monitor OSGi AET bundles in the root /aet directory
-felix.fileinstall.dir=/aet/bundles
+felix.fileinstall.dir=/aet/custom/bundles

--- a/karaf/etc/org.apache.felix.fileinstall-custom-configs.cfg
+++ b/karaf/etc/org.apache.felix.fileinstall-custom-configs.cfg
@@ -1,2 +1,2 @@
 # Monitor OSGi AET configs in the root /aet directory
-felix.fileinstall.dir=/aet/configs
+felix.fileinstall.dir=/aet/custom/configs

--- a/karaf/etc/org.apache.felix.fileinstall-custom-features.cfg
+++ b/karaf/etc/org.apache.felix.fileinstall-custom-features.cfg
@@ -1,2 +1,2 @@
 # Monitor OSGi AET features in the root /aet directory
-felix.fileinstall.dir=/aet/features
+felix.fileinstall.dir=/aet/custom/features


### PR DESCRIPTION
Introducing `core` and `custom` AET artifacts in the Karaf image and healthcheck basing on the [fabric8 healthchecks](https://fabric8.io/guide/karaf.html#add-custom-heath-checks).