### PR TITLE
Proxy all API endpoints via report app: /api, /suite, /xunit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Not released yet
 Nothing now :)
 
+- [PR-21](https://github.com/Skejven/aet-docker/pull/21) Proxy all API endpoints via report app: /api, /suite, /xunit
+
 # 0.13.0
 - [PR-20](https://github.com/Skejven/aet-docker/pull/20) - `core` and `custom` AET artifacts in the Karaf image and healthcheck basing on the [fabric8 healthchecks](https://fabric8.io/guide/karaf.html#add-custom-heath-checks).
 

--- a/example-aet-swarm/aet-swarm.yml
+++ b/example-aet-swarm/aet-swarm.yml
@@ -31,7 +31,7 @@ services:
   hub:
     image: selenium/hub:3.14.0-arsenic
     ports:
-      - "4444:4444"
+      - '4444:4444'
     deploy:
       mode: global
       placement:
@@ -72,24 +72,24 @@ services:
     volumes:
       - mongo-data:/data/db
     ports:
-      - "27017:27017"
+      - '27017:27017'
     networks:
       - private
 
   activemq:
     image: skejven/aet_activemq:0.13.0
     ports:
-      - "8161:8161"
+      - '8161:8161'
     networks:
       - private
 
   browsermob:
-   image: skejven/aet_browsermob:0.13.0
-   ports:
-    - "8080:8080"
-    - "8281-8681:8281-8681"
-   networks:
-     - private
+    image: skejven/aet_browsermob:0.13.0
+    ports:
+      - '8080:8080'
+      - '8281-8681:8281-8681'
+    networks:
+      - private
 
   karaf:
     image: skejven/aet_karaf:0.13.0
@@ -107,20 +107,20 @@ services:
       - ./bundles:/aet/custom/bundles
       - ./features:/aet/custom/features
     ports:
-      - "8181:8181"
-#      - "5005:5005" # uncomment to be able to connect Karaf in debug mode
-#    environment:
-#      - KARAF_DEBUG=true # uncomment (with section above) to start Karaf in debug mode
+      - '8181:8181'
+    #      - "5005:5005" # uncomment to be able to connect Karaf in debug mode
+    #    environment:
+    #      - KARAF_DEBUG=true # uncomment (with section above) to start Karaf in debug mode
     networks:
       - private
 
   report:
     image: skejven/aet_report:0.13.0
     ports:
-      - "80:80"
-#    volumes:
-#      - ./report:/usr/local/apache2/htdocs
-#    environment:
-#      - AET_WEB_API=http://my.karaf.com/api # uncomment to configure custom AET Web API endpoint
+      - '80:80'
+    #    volumes:
+    #      - ./report:/usr/local/apache2/htdocs
+    #    environment:
+    #      - AET_WEB_API=http://my.karaf.com # uncomment to configure custom AET Web API endpoint
     networks:
       - private

--- a/report/Dockerfile
+++ b/report/Dockerfile
@@ -31,7 +31,7 @@ ENV APACHE_WWW_DIR      /usr/local/apache2/htdocs
 ENV APACHE_LOG_DIR      /usr/local/apache2/logs
 ENV APACHE_CONFIG_DIR   /usr/local/apache2/conf
 ENV APACHE_MODULES      "deflate proxy proxy_http"
-ENV AET_WEB_API         http://karaf:8181/api
+ENV AET_WEB_API         http://karaf:8181
 
 # clear default content
 RUN rm -rf ${APACHE_WWW_DIR}}/*

--- a/report/aet.conf
+++ b/report/aet.conf
@@ -28,6 +28,14 @@
 
   <Location "/api">
     Header set Access-Control-Allow-Origin "*"
-    ProxyPass ${AET_WEB_API}
+    ProxyPass ${AET_WEB_API}/api
+  </Location>
+
+  <Location "/suite">
+    ProxyPass ${AET_WEB_API}/suite
+  </Location>
+
+  <Location "/xunit">
+    ProxyPass ${AET_WEB_API}/xunit
   </Location>
 </VirtualHost>


### PR DESCRIPTION
In order to avoid direct connectivity between `aet.sh` and Apache Karaf all HTTP endpoints should be proxied via AET web server (report app). At the time of writing only `/api` is exposed this way, but there are 2 others: `/suite` and `/xuint`. This PR adds reverse proxy rules for both of them and adjusts `AET_WEB_API` variable accordingly.

Full flow from `aet.sh` perspective:

![aet_sh_flow](https://user-images.githubusercontent.com/6334715/77361073-db291200-6d4e-11ea-9aa7-8461546f840b.jpg)
 