### PR TITLE
default replicas number change

### DIFF
--- a/example-aet-swarm/aet-swarm.yml
+++ b/example-aet-swarm/aet-swarm.yml
@@ -49,11 +49,11 @@ services:
     environment:
       - HUB_HOST=hub
       - HUB_PORT=4444
-      - NODE_MAX_INSTANCES=2
-      - NODE_MAX_SESSION=2
+      - NODE_MAX_INSTANCES=1
+      - NODE_MAX_SESSION=1
     entrypoint: bash -c 'SE_OPTS="-host $$HOSTNAME -port 5556" /opt/bin/entry_point.sh'
     deploy:
-      replicas: 3
+      replicas: 6
     networks:
       - private
 


### PR DESCRIPTION
Changes was made to improve stability of test results.
I've noticed that tests results are more stable wen we use only one instance and session per replica. 
If we will use more instances and sessions per replica, we can have more false/positive results like some 1px shift related with page rendering etc.