### PR TITLE
AET Docker client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Not released yet
+- [PR-26](https://github.com/Skejven/aet-docker/pull/26) - AET Docker client for running AET suites with no dependencies but Docker
 - [PR-22](https://github.com/Skejven/aet-docker/pull/22) - changed no of Selenium Grid Nodes replicas in order to improve tests results stability.
 - [PR-23](https://github.com/Skejven/aet-docker/pull/23) - updated mongodb image version to `3.6`. **Important**: if you are upgrading AET from the version that used mongo 3.2, please read carefully upgrade notes before migrating. Updated docker swarm schema to `3.7`.
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ You may find released versions of AET Docker images at [Docker Hub](https://clou
 - [Docker Images](#docker-images)
   * [AET ActiveMq](#aet-activemq)
   * [AET Browsermob](#aet-browsermob)
-  * [AET Apache Karaf](#aet-apache-karaf)
-  * [AET Apache Server](#aet-apache-server)
+  * [AET Karaf](#aet-karaf)
+  * [AET Report](#aet-report)
+  * [AET Docker Client](#aet-docker-client)
 - [Running AET instance with Docker Swarm](#running-aet-instance-with-docker-swarm)
   * [Prerequisites](#prerequisites)
   * [Instance setup](#instance-setup)
@@ -19,7 +20,9 @@ You may find released versions of AET Docker images at [Docker Hub](https://clou
     + [OSGi configs](#osgi-configs)
     + [Throughput and scaling](#throughput-and-scaling)
   * [Updating instance](#updating-instance)
-  * [Executing AET Suite](#executing-aet-suite)
+  * [Running AET Suite](#running-aet-suite)
+    + [Docker Client](#docker-client)
+    + [Other Clients](#other-clients)
   * [Best practices](#best-practices)
   * [Available consoles](#available-consoles)
   * [Troubleshooting](#troubleshooting)
@@ -54,6 +57,8 @@ All custom AET extensions are kept in the `/aet/custom` directory.
 Runs [Apache Server](https://httpd.apache.org/) that hosts [AET Report](https://github.com/Cognifide/aet/wiki/SuiteReport).
 The [AET report application](https://github.com/Cognifide/aet/tree/master/report) is placed under `/usr/local/apache2/htdocs`.
 Defines very basic `VirtualHost` (see [aet.conf](https://github.com/Skejven/aet-docker/blob/master/report/aet.conf)).
+### AET Docker Client
+[AET bash client](https://github.com/Cognifide/aet/tree/master/client/client-scripts) embedded into Docker image with all its dependencies (`jq`, `curl`, `xmllint`).
 
 ## Running AET instance with Docker Swarm
 This chapter shows how to setup a fully functional AET instance with [Docker Swarm](https://docs.docker.com/engine/swarm/).
@@ -154,6 +159,10 @@ When you see status `healthy` it means Karaf is running correctly
 > IMAGE                     STATUS
 > skejven/aet_karaf:0.4.0   Up 20 minutes (healthy)
 
+Now you may want to run a sample suite by executing:
+```
+docker run skejven/aet_client
+```
 
 #### Minimum requirements
 To run example AET instance make sure that machine you run it at has at least enabled:
@@ -240,7 +249,33 @@ detect automatic changes in the config. You will need to restart Karaf service a
 changes in the configuration files (e.g. by removing `aet_karaf` service and running stack deploy).
 
 
-### Executing AET Suite
+### Running AET Suite
+There are couple of ways to start AET Suite.
+
+#### Docker Client
+You may use an image that embeds AET Bash client together with its dependencies by running:
+> `docker run --rm -v "$(pwd)/suite:/aet/suite" -v "$(pwd)/report:/aet/report" skejven/aet_client AET_INSTANCE_IP /aet/suite/SUITE_YOU_WANT_TO_RUN`
+
+E.g. when you run AET on Docker for Mac/Win and have following setup:
+```
+.
+├── custom
+│   └── my-suite.xml
+```
+and want to run `my-suite.xml` file, simply run:
+`docker run --rm -v "$(pwd)/custom:/aet/suite" -v "$(pwd)/report:/aet/report" skejven/aet_client http://host.docker.internal /aet/suite/my-suite.xml`
+
+The results will be saved to the `report` directory:
+```
+.
+├── report
+│   ├── redirect.html
+│   └── xUnit.xml
+```
+
+> Notice that we are using here `host.docker.internal` as the address of AET instance - that works only for Docker for Mac/Win with local AET setup. In other cases, use the AET server's IP/domain.
+
+#### Other Clients
 To run AET Suite simply define `endpointDomain` to AET Karaf IP with `8181` port, e.g.:
 > `./aet.sh http://localhost:8181`
 or

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,45 @@
+#
+# AET Docker
+#
+# Copyright (C) 2020 Maciej Laskowski
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM alpine:3.12.0
+LABEL maintainer="Maciej Laskowski <skejven@gmail.com>"
+
+RUN apk add --no-cache \
+    bash \
+    curl \
+    jq \
+    libxml2-utils
+
+# Download AET bash client and sample suite
+RUN mkdir -p /aet/client \
+  && curl -sS https://raw.githubusercontent.com/Cognifide/aet/master/client/client-scripts/aet.sh > /aet/client/aet.sh \
+  && chmod +x /aet/client/aet.sh
+
+# Sample suite
+RUN mkdir -p /aet/suite
+COPY ./example.xml /aet/suite/example.xml
+VOLUME /aet/suite
+
+# Report
+RUN mkdir -p /aet/report
+VOLUME /aet/report
+
+WORKDIR /aet/report
+
+ENTRYPOINT ["/aet/client/aet.sh"]
+CMD ["http://host.docker.internal:8181", "/aet/suite/example.xml"]

--- a/client/example.xml
+++ b/client/example.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suite name="example" company="example" project="example">
+  <test name="layout-test">
+    <collect>
+      <open/>
+      <wait-for-page-loaded />
+      <resolution width="1280" height="1024"/>
+      <sleep duration="2000"/>
+      <screen name="desktop"/>
+    </collect>
+    <compare>
+      <screen comparator="layout"/>
+    </compare>
+    <urls>
+      <url href="https://www.google.com"/>
+    </urls>
+  </test>
+</suite>


### PR DESCRIPTION
Introducing new way to run AET suites with no extra dependencies but Docker.

You may use an image that embeds AET Bash client together with its dependencies by running:
> `docker run --rm -v "$(pwd)/suite:/aet/suite" -v "$(pwd)/report:/aet/report" skejven/aet_client AET_INSTANCE_IP /aet/suite/SUITE_YOU_WANT_TO_RUN`

E.g. when you run AET on Docker for Mac/Win and have following setup:
```
.
├── custom
│   └── my-suite.xml
```
and want to run `my-suite.xml` file, simply run:
`docker run --rm -v "$(pwd)/custom:/aet/suite" -v "$(pwd)/report:/aet/report" skejven/aet_client http://host.docker.internal /aet/suite/my-suite.xml`

The results will be saved to the `report` directory:
```
.
├── report
│   ├── redirect.html
│   └── xUnit.xml
```

> Notice that we are using here `host.docker.internal` as the address of AET instance - that works only for Docker for Mac/Win with local AET setup. In other cases, use the AET server's IP/domain.
