### PR TITLE
Karaf support for docker secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Not released yet
-No new features so far...
+- [PR-28](https://github.com/Skejven/aet-docker/pull/28) - Before the start of a Karaf service, Docker secrets are exported to environment variables.
 
 # 0.14.0
 - [PR-27](https://github.com/Skejven/aet-docker/pull/27) - Karaf provisioned with all dependencies - offline mode provisioning support.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ You may find released versions of AET Docker images at [Docker Hub](https://clou
   * [Configuration](#configuration)
     + [OSGi configs](#osgi-configs)
     + [Throughput and scaling](#throughput-and-scaling)
+    + [Docker secrets](#docker-secrets)
   * [Updating instance](#updating-instance)
   * [Running AET Suite](#running-aet-suite)
     + [Docker Client](#docker-client)
@@ -54,6 +55,7 @@ It contains all AET modules (bundles): Runner, Workers, Web-API, Datastorage, Ex
 with all their dependencies required (no internet access required to provision).
 [AET application core](https://github.com/Cognifide/aet) is located in the `/aet/core` directory.
 All custom AET extensions are kept in the `/aet/custom` directory.
+Before the start of a Karaf service, Docker secrets are exported to environment variables. Read more in [secrets](#docker-secrets) section.
 ### AET Report 
 Runs [Apache Server](https://httpd.apache.org/) that hosts [AET Report](https://github.com/Cognifide/aet/wiki/SuiteReport).
 The [AET report application](https://github.com/Cognifide/aet/tree/master/report) is placed under `/usr/local/apache2/htdocs`.
@@ -234,6 +236,13 @@ So, the `TOTAL_NUMBER_OF_BROWSERS` is `6` (`3 replicas x 2 sessions`).
 That number should be set for following configs:
 - `maxMessagesInCollectorQueue` in `com.cognifide.aet.runner.RunnerConfiguration.cfg`
 - `collectorInstancesNo` in `com.cognifide.aet.worker.listeners.WorkersListenersService.cfg`
+
+#### Docker secrets
+AET Karaf image reads all files in the `/run/secrets/` directory matching `KARAF_*` pattern export them as environment variable.
+See the [Karaf entrypoint][/blob/master/karaf/entrypoint.sh] for details.
+
+E.g.
+If the file `/run/secrets/KARAF_MY_SECRET` is found, its content will be exported to `MY_SECRET` environment variable.
 
 ### Updating instance
 You may update configuration files directly from your host 

--- a/example-aet-swarm/README.md
+++ b/example-aet-swarm/README.md
@@ -24,7 +24,9 @@ AET stack defined in this example runs:
 │   └── com.github.skejven.collector.LighthouseCollectorFactory.cfg
 ├── features
 │   └── custom-features.xml
-└── report
+├── report
+└── secrets
+    └── KARAF_EXAMPLE_SECRET
 ```
 
 - `aet-swarm.yml` - this file contains configuration file to run AET [single-node swarm cluster](https://docs.docker.com/engine/swarm/key-concepts/)
@@ -32,6 +34,7 @@ AET stack defined in this example runs:
 - `configs` - directory mounted to the `/aet/custom/configs` in the Karaf service, contains OSGi components in form of `.cfg` files
 - `features` - directory mounted to the `/aet/custom/features in the Karaf service`, contains [Karaf provisioning](https://karaf.apache.org/manual/latest/provisioning) configuration files - called features
 - `report` - directory that may contain custom AET report application, if mounted to `/usr/local/apache2/htdocs` volume in the Report service, it will override default [AET Report application](https://github.com/Cognifide/aet/tree/master/report)
+- `secrets` - directory contains example [Docker secret](https://docs.docker.com/engine/swarm/secrets/) files. They are scanned before Karaf starts and exported as environment variables. Read more in the [secrets configuration](https://github.com/Skejven/aet-docker#docker-secrets).
 
 ## Karaf healthcheck
 Karaf's service in this sample docker instance have [healthcheck](https://docs.docker.com/compose/compose-file/#healthcheck). It simply checks the dedicated service's endpoint `/health-check` that responses with `200` when everything is ready, with error code otherwise. If the healthcheck fails, swarm will automatically restart the service.

--- a/example-aet-swarm/aet-swarm.yml
+++ b/example-aet-swarm/aet-swarm.yml
@@ -106,6 +106,8 @@ services:
       - ./configs:/aet/custom/configs
       - ./bundles:/aet/custom/bundles
       - ./features:/aet/custom/features
+    secrets:
+      - KARAF_EXAMPLE_SECRET
     ports:
       - '8181:8181'
     #      - '5005:5005' # uncomment to be able to connect Karaf in debug mode
@@ -124,3 +126,7 @@ services:
     #      - AET_WEB_API=http://my.karaf.com # uncomment to configure custom AET Web API endpoint
     networks:
       - private
+
+secrets:
+  KARAF_EXAMPLE_SECRET:
+    file: secrets/KARAF_EXAMPLE_SECRET

--- a/example-aet-swarm/secrets/KARAF_EXAMPLE_SECRET
+++ b/example-aet-swarm/secrets/KARAF_EXAMPLE_SECRET
@@ -1,0 +1,1 @@
+ex@mpl3-s3cret-v4lue

--- a/karaf/Dockerfile
+++ b/karaf/Dockerfile
@@ -102,8 +102,12 @@ RUN mv /opt/karaf/deploy/aet-*.xml /aet/core/features \
 
 RUN chown -R ${KARAF_USER}.${KARAF_USER} /opt/karaf
 
+COPY entrypoint.sh /opt/karaf/entrypoint.sh
+RUN chmod a+x /opt/karaf/entrypoint.sh && chown -R ${KARAF_USER}.${KARAF_USER} /opt/karaf/entrypoint.sh
+
 EXPOSE 1099 8101 8181 44444
 
 USER ${KARAF_USER}
 
-CMD ["/opt/karaf/bin/karaf", "run"]
+ENTRYPOINT ["/opt/karaf/entrypoint.sh"]
+CMD ["run"]

--- a/karaf/entrypoint.sh
+++ b/karaf/entrypoint.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# AET Docker
+#
+# Copyright (C) 2020 Maciej Laskowski
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -e
+
+KARAF_COMMAND=$1
+
+read_secrets() {
+  echo "Exporting secrets to env..."
+  for file in /run/secrets/KARAF_*; do
+    envName=$(echo "$file" | awk -F"KARAF_" '{print $2}')
+    envVal="$(<"${file}")"
+    echo "Exporting: $envName"
+    export "$envName"="$envVal"
+  done
+}
+
+if [ "$KARAF_COMMAND" = 'run' ]; then
+  [ -d "/run/secrets" ] && read_secrets || echo "No secrets configured."
+  echo "Running karaf"
+  exec /opt/karaf/bin/karaf $KARAF_COMMAND "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
AET Karaf image reads all files in the `/run/secrets/` directory matching `KARAF_*` pattern export them as environment variable.
See the [Karaf entrypoint][/blob/master/karaf/entrypoint.sh] for details.

E.g.
If the file `/run/secrets/KARAF_MY_SECRET` is found, its content will be exported to `MY_SECRET` environment variable.

This feature is done to support login modifier reading from env (https://github.com/Cognifide/aet/pull/583).